### PR TITLE
Apply a few minor tweaks for cache and size

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,6 +1,10 @@
 # vim:set ft=dockerfile:
-FROM       java:8
+FROM       java:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
+
+# Create Nuxeo user
+ENV NUXEO_USER nuxeo
+RUN useradd -m -d /home/$NUXEO_USER -s /bin/bash $NUXEO_USER
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -14,9 +18,8 @@ RUN arch="$(dpkg --print-architecture)" \
 
 
 # Add needed convert tools
-RUN apt-get update && apt-get install -y --no-install-recommends \    
+RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
-    sudo \
     locales \
     pwgen \
     imagemagick \
@@ -27,21 +30,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwpd-tools \
     exiftool \
     ghostscript \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*  
-
-# Create Nuxeo user
-RUN useradd -m -d /home/nuxeo -p nuxeo nuxeo && adduser nuxeo sudo && chsh -s /bin/bash nuxeo
+ && rm -rf /var/lib/apt/lists/*
 
 ENV NUXEO_VERSION 6.0
 ENV NUXEO_MD5 b8cbc0b2858b0697a541be49feb24571
-ENV NUXEO_USER nuxeo
 ENV NUXEO_HOME /opt/nuxeo/server
-ENV NUXEOCTL $NUXEO_HOME/bin/nuxeoctl
 
 # Add distribution
-ADD http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip /tmp/nuxeo-distribution-tomcat.zip
-RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
+RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip" -o /tmp/nuxeo-distribution-tomcat.zip \
+    && echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && mkdir -p /tmp/nuxeo-distribution $(dirname $NUXEO_HOME) \
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
@@ -49,10 +46,10 @@ RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
-
+ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
-CMD ["./bin/nuxeoctl","console"]
+CMD ["nuxeoctl","console"]

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 NUXEO_CONF=$NUXEO_HOME/bin/nuxeo.conf
 
-if [ "$1" = './bin/nuxeoctl' ]; then
+if [ "$1" = 'nuxeoctl' ]; then
   if [ ! -f $NUXEO_HOME/configured ]; then
 
     # PostgreSQL conf
@@ -90,21 +90,21 @@ EOF
 
   ## Executed at each start
   if [ -n "$NUXEO_CLID"  ] && [ $(NUXEO_INSTALL_HOTFIX:='true') = "true" ]; then
-      gosu $NUXEO_USER $NUXEOCTL mp-hotfix --accept=true
+      gosu $NUXEO_USER nuxeoctl mp-hotfix --accept=true
   fi
 
   # Install packages if exist
   if [ -n "$NUXEO_PACKAGES" ]; then
-    gosu $NUXEO_USER $NUXEOCTL mp-install $NUXEO_PACKAGES --relax=false --accept=true
+    gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
 
-  if [ $2 = "console" ]; then
-    exec gosu $NUXEO_USER $NUXEOCTL console
+  if [ "$2" = "console" ]; then
+    exec gosu $NUXEO_USER nuxeoctl console
   else
-    exec gosu $NUXEO_USER $@
+    exec gosu $NUXEO_USER "$@"
   fi
 
 fi
 
 
-exec $@
+exec "$@"

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -1,6 +1,10 @@
 # vim:set ft=dockerfile:
-FROM       java:8
+FROM       java:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
+
+# Create Nuxeo user
+ENV NUXEO_USER nuxeo
+RUN useradd -m -d /home/$NUXEO_USER -s /bin/bash $NUXEO_USER
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -14,9 +18,8 @@ RUN arch="$(dpkg --print-architecture)" \
 
 
 # Add needed convert tools
-RUN apt-get update && apt-get install -y --no-install-recommends \    
+RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
-    sudo \
     locales \
     pwgen \
     imagemagick \
@@ -27,21 +30,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwpd-tools \
     exiftool \
     ghostscript \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*  
-
-# Create Nuxeo user
-RUN useradd -m -d /home/nuxeo -p nuxeo nuxeo && adduser nuxeo sudo && chsh -s /bin/bash nuxeo
+ && rm -rf /var/lib/apt/lists/*
 
 ENV NUXEO_VERSION 7.10
 ENV NUXEO_MD5 de2084b1a6fab4b1c8fb769903b044f2
-ENV NUXEO_USER nuxeo
 ENV NUXEO_HOME /opt/nuxeo/server
-ENV NUXEOCTL $NUXEO_HOME/bin/nuxeoctl
 
 # Add distribution
-ADD http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip /tmp/nuxeo-distribution-tomcat.zip
-RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
+RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip" -o /tmp/nuxeo-distribution-tomcat.zip \
+    && echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && mkdir -p /tmp/nuxeo-distribution $(dirname $NUXEO_HOME) \
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
@@ -49,10 +46,10 @@ RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
-
+ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
-CMD ["./bin/nuxeoctl","console"]
+CMD ["nuxeoctl","console"]

--- a/7.10/docker-entrypoint.sh
+++ b/7.10/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 NUXEO_CONF=$NUXEO_HOME/bin/nuxeo.conf
 
-if [ "$1" = './bin/nuxeoctl' ]; then
+if [ "$1" = 'nuxeoctl' ]; then
   if [ ! -f $NUXEO_HOME/configured ]; then
 
     # PostgreSQL conf
@@ -90,21 +90,21 @@ EOF
 
   ## Executed at each start
   if [ -n "$NUXEO_CLID"  ] && [ $(NUXEO_INSTALL_HOTFIX:='true') = "true" ]; then
-      gosu $NUXEO_USER $NUXEOCTL mp-hotfix --accept=true
+      gosu $NUXEO_USER nuxeoctl mp-hotfix --accept=true
   fi
 
   # Install packages if exist
   if [ -n "$NUXEO_PACKAGES" ]; then
-    gosu $NUXEO_USER $NUXEOCTL mp-install $NUXEO_PACKAGES --relax=false --accept=true
+    gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
 
-  if [ $2 = "console" ]; then
-    exec gosu $NUXEO_USER $NUXEOCTL console
+  if [ "$2" = "console" ]; then
+    exec gosu $NUXEO_USER nuxeoctl console
   else
-    exec gosu $NUXEO_USER $@
+    exec gosu $NUXEO_USER "$@"
   fi
 
 fi
 
 
-exec $@
+exec "$@"

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,6 +1,10 @@
 # vim:set ft=dockerfile:
-FROM       java:8
+FROM       java:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
+
+# Create Nuxeo user
+ENV NUXEO_USER nuxeo
+RUN useradd -m -d /home/$NUXEO_USER -s /bin/bash $NUXEO_USER
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -14,9 +18,8 @@ RUN arch="$(dpkg --print-architecture)" \
 
 
 # Add needed convert tools
-RUN apt-get update && apt-get install -y --no-install-recommends \    
+RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
-    sudo \
     locales \
     pwgen \
     imagemagick \
@@ -27,21 +30,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwpd-tools \
     exiftool \
     ghostscript \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*  
-
-# Create Nuxeo user
-RUN useradd -m -d /home/nuxeo -p nuxeo nuxeo && adduser nuxeo sudo && chsh -s /bin/bash nuxeo
+ && rm -rf /var/lib/apt/lists/*
 
 ENV NUXEO_VERSION 7.4
 ENV NUXEO_MD5 2141da25bb5022250c8c99f0d19632e3
-ENV NUXEO_USER nuxeo
 ENV NUXEO_HOME /opt/nuxeo/server
-ENV NUXEOCTL $NUXEO_HOME/bin/nuxeoctl
 
 # Add distribution
-ADD http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip /tmp/nuxeo-distribution-tomcat.zip
-RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
+RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip" -o /tmp/nuxeo-distribution-tomcat.zip \
+    && echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && mkdir -p /tmp/nuxeo-distribution $(dirname $NUXEO_HOME) \
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
@@ -49,10 +46,10 @@ RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
-
+ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
-CMD ["./bin/nuxeoctl","console"]
+CMD ["nuxeoctl","console"]

--- a/7.4/docker-entrypoint.sh
+++ b/7.4/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 NUXEO_CONF=$NUXEO_HOME/bin/nuxeo.conf
 
-if [ "$1" = './bin/nuxeoctl' ]; then
+if [ "$1" = 'nuxeoctl' ]; then
   if [ ! -f $NUXEO_HOME/configured ]; then
 
     # PostgreSQL conf
@@ -90,21 +90,21 @@ EOF
 
   ## Executed at each start
   if [ -n "$NUXEO_CLID"  ] && [ $(NUXEO_INSTALL_HOTFIX:='true') = "true" ]; then
-      gosu $NUXEO_USER $NUXEOCTL mp-hotfix --accept=true
+      gosu $NUXEO_USER nuxeoctl mp-hotfix --accept=true
   fi
 
   # Install packages if exist
   if [ -n "$NUXEO_PACKAGES" ]; then
-    gosu $NUXEO_USER $NUXEOCTL mp-install $NUXEO_PACKAGES --relax=false --accept=true
+    gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
 
-  if [ $2 = "console" ]; then
-    exec gosu $NUXEO_USER $NUXEOCTL console
+  if [ "$2" = "console" ]; then
+    exec gosu $NUXEO_USER nuxeoctl console
   else
-    exec gosu $NUXEO_USER $@
+    exec gosu $NUXEO_USER "$@"
   fi
 
 fi
 
 
-exec $@
+exec "$@"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,10 @@
 # vim:set ft=dockerfile:
-FROM       java:8
+FROM       java:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
+
+# Create Nuxeo user
+ENV NUXEO_USER nuxeo
+RUN useradd -m -d /home/$NUXEO_USER -s /bin/bash $NUXEO_USER
 
 # grab gosu for easy step-down from root
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
@@ -14,9 +18,8 @@ RUN arch="$(dpkg --print-architecture)" \
 
 
 # Add needed convert tools
-RUN apt-get update && apt-get install -y --no-install-recommends \    
+RUN apt-get update && apt-get install -y --no-install-recommends \
     perl \
-    sudo \
     locales \
     pwgen \
     imagemagick \
@@ -27,21 +30,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwpd-tools \
     exiftool \
     ghostscript \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*  
-
-# Create Nuxeo user
-RUN useradd -m -d /home/nuxeo -p nuxeo nuxeo && adduser nuxeo sudo && chsh -s /bin/bash nuxeo
+ && rm -rf /var/lib/apt/lists/*
 
 ENV NUXEO_VERSION 7.10
 ENV NUXEO_MD5 de2084b1a6fab4b1c8fb769903b044f2
-ENV NUXEO_USER nuxeo
 ENV NUXEO_HOME /opt/nuxeo/server
-ENV NUXEOCTL $NUXEO_HOME/bin/nuxeoctl
 
 # Add distribution
-ADD http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip /tmp/nuxeo-distribution-tomcat.zip
-RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
+RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VERSION}-tomcat.zip" -o /tmp/nuxeo-distribution-tomcat.zip \
+    && echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && mkdir -p /tmp/nuxeo-distribution $(dirname $NUXEO_HOME) \
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
@@ -49,10 +46,10 @@ RUN echo "$NUXEO_MD5 /tmp/nuxeo-distribution-tomcat.zip" | md5sum -c - \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
-
+ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]
 EXPOSE 8080
-CMD ["./bin/nuxeoctl","console"]
+CMD ["nuxeoctl","console"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 NUXEO_CONF=$NUXEO_HOME/bin/nuxeo.conf
 
-if [ "$1" = './bin/nuxeoctl' ]; then
+if [ "$1" = 'nuxeoctl' ]; then
   if [ ! -f $NUXEO_HOME/configured ]; then
 
     # PostgreSQL conf
@@ -90,21 +90,21 @@ EOF
 
   ## Executed at each start
   if [ -n "$NUXEO_CLID"  ] && [ $(NUXEO_INSTALL_HOTFIX:='true') = "true" ]; then
-      gosu $NUXEO_USER $NUXEOCTL mp-hotfix --accept=true
+      gosu $NUXEO_USER nuxeoctl mp-hotfix --accept=true
   fi
 
   # Install packages if exist
   if [ -n "$NUXEO_PACKAGES" ]; then
-    gosu $NUXEO_USER $NUXEOCTL mp-install $NUXEO_PACKAGES --relax=false --accept=true
+    gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
 
-  if [ $2 = "console" ]; then
-    exec gosu $NUXEO_USER $NUXEOCTL console
+  if [ "$2" = "console" ]; then
+    exec gosu $NUXEO_USER nuxeoctl console
   else
-    exec gosu $NUXEO_USER $@
+    exec gosu $NUXEO_USER "$@"
   fi
 
 fi
 
 
-exec $@
+exec "$@"


### PR DESCRIPTION
These minor tweaks take the 7.10 image from ~1.7GB down to ~1.2GB.
1. switch from `java:8` to `java:8-jre` (JDK doesn't appear to be necessary)
2. move user creation up to the top since it isn't likely to change
3. remove `sudo` which doesn't appear to be necessary (is it used within Nuxeo somewhere?  I tried a lot and couldn't find anything, and passwordless sudo wasn't configured so even if it were it likely wouldn't have worked)
4. remove explicit `apt-get clean`, which is done automatically by the base image configuration directly
5. switch from `ADD` to using `curl` (included in the base image already) so that we can remove the downloaded zip file in the same layer and save space
6. add `bin` to `PATH` so we can avoid the `NUXEOCTL` env variable and just invoke `nuxeoctl` directly (making the user experience simpler too)
7. add quotes around `$@` in the entrypoint to ensure spaces in parameters are passed through correctly (see https://www.gnu.org/software/bash/manual/bashref.html#index-parameters_002c-special; "When the expansion occurs within double quotes, each parameter expands to a separate word.")

Since you've got a template, I've also split the change into two separate commits to hopefully make it easier to review (one updating the template and one regenerating all the Dockerfiles).
