### PR TITLE
Adds an additionnal intialization possibility

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -50,6 +50,7 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
+RUN mkdir /docker-entrypoint-initnuxeo.d
 ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -69,18 +69,6 @@ if [ "$1" = 'nuxeoctl' ]; then
       echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
     fi
 
-    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
-    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
-      mkdir -p $NUXEO_TRANSIENT_STORE
-      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
-
-      #removes transients stores if exists to allow symbolic link creation
-      if [ -d $NUXEO_DATA/transientstores ]; then
-          rm -rf $NUXEO_DATA/transientstores
-      fi
-      mkdir -p $NUXEO_DATA/transientstores
-      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
-    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -62,12 +62,31 @@ if [ "$1" = 'nuxeoctl' ]; then
     mkdir -p ${NUXEO_LOG:=/var/log/nuxeo}
     mkdir -p /var/run/nuxeo
 
+    # The binary store environment variable is defined : 1/ creates the folder with proper rights; 2/ fills in the corresponding property within nuxeo.conf
+    if [ -n "$NUXEO_BINARY_STORE" ]; then
+      mkdir -p $NUXEO_BINARY_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_BINARY_STORE
+      echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
+    fi
+
+    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
+    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
+      mkdir -p $NUXEO_TRANSIENT_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
+
+      #removes transients stores if exists to allow symbolic link creation
+      if [ -d $NUXEO_DATA/transientstores ]; then
+          rm -rf $NUXEO_DATA/transientstores
+      fi
+      mkdir -p $NUXEO_DATA/transientstores
+      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
+    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG
     chown -R $NUXEO_USER:$NUXEO_USER /var/run/nuxeo
 
-    cat << EOF >> $NUXEO_HOME/bin/nuxeo.conf
+    cat << EOF >> $NUXEO_CONF
 nuxeo.log.dir=$NUXEO_LOG
 nuxeo.pid.dir=/var/run/nuxeo
 nuxeo.data.dir=$NUXEO_DATA
@@ -97,6 +116,13 @@ EOF
   if [ -n "$NUXEO_PACKAGES" ]; then
     gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
+  for f in /docker-entrypoint-initnuxeo.d/*; do
+    case "$f" in
+      *.sh)  echo "$0: running $f"; . "$f" ;;
+      *)     echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
 
   if [ "$2" = "console" ]; then
     exec gosu $NUXEO_USER nuxeoctl console

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -43,6 +43,7 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
     && mv /tmp/nuxeo-distribution/$DISTDIR $NUXEO_HOME \
+    && sed -i -e "s/^org.nuxeo.distribution.package.*/org.nuxeo.distribution.package=docker/" $NUXEO_HOME/templates/common/config/distribution.properties \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -51,7 +51,6 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
 RUN mkdir /docker-entrypoint-initnuxeo.d
-
 ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -43,9 +43,10 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && unzip -q -d /tmp/nuxeo-distribution /tmp/nuxeo-distribution-tomcat.zip \
     && DISTDIR=$(/bin/ls /tmp/nuxeo-distribution | head -n 1) \
     && mv /tmp/nuxeo-distribution/$DISTDIR $NUXEO_HOME \
-    && sed -i -e "s/^org.nuxeo.distribution.package.*/org.nuxeo.distribution.package=docker/" $NUXEO_HOME/templates/common/config/distribution.properties \
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
+
+RUN mkdir /docker-entrypoint-initnuxeo.d
 
 ENV PATH $NUXEO_HOME/bin:$PATH
 

--- a/7.10/docker-entrypoint.sh
+++ b/7.10/docker-entrypoint.sh
@@ -81,10 +81,6 @@ if [ "$1" = 'nuxeoctl' ]; then
       mkdir -p $NUXEO_DATA/transientstores
       ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
     fi
-
-
-
-
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG
@@ -120,7 +116,6 @@ EOF
   if [ -n "$NUXEO_PACKAGES" ]; then
     gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
-
   for f in /docker-entrypoint-initnuxeo.d/*; do
     case "$f" in
       *.sh)  echo "$0: running $f"; . "$f" ;;

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -50,6 +50,7 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
+RUN mkdir /docker-entrypoint-initnuxeo.d
 ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME

--- a/7.4/docker-entrypoint.sh
+++ b/7.4/docker-entrypoint.sh
@@ -69,18 +69,6 @@ if [ "$1" = 'nuxeoctl' ]; then
       echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
     fi
 
-    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
-    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
-      mkdir -p $NUXEO_TRANSIENT_STORE
-      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
-
-      #removes transients stores if exists to allow symbolic link creation
-      if [ -d $NUXEO_DATA/transientstores ]; then
-          rm -rf $NUXEO_DATA/transientstores
-      fi
-      mkdir -p $NUXEO_DATA/transientstores
-      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
-    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG

--- a/7.4/docker-entrypoint.sh
+++ b/7.4/docker-entrypoint.sh
@@ -62,12 +62,31 @@ if [ "$1" = 'nuxeoctl' ]; then
     mkdir -p ${NUXEO_LOG:=/var/log/nuxeo}
     mkdir -p /var/run/nuxeo
 
+    # The binary store environment variable is defined : 1/ creates the folder with proper rights; 2/ fills in the corresponding property within nuxeo.conf
+    if [ -n "$NUXEO_BINARY_STORE" ]; then
+      mkdir -p $NUXEO_BINARY_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_BINARY_STORE
+      echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
+    fi
+
+    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
+    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
+      mkdir -p $NUXEO_TRANSIENT_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
+
+      #removes transients stores if exists to allow symbolic link creation
+      if [ -d $NUXEO_DATA/transientstores ]; then
+          rm -rf $NUXEO_DATA/transientstores
+      fi
+      mkdir -p $NUXEO_DATA/transientstores
+      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
+    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG
     chown -R $NUXEO_USER:$NUXEO_USER /var/run/nuxeo
 
-    cat << EOF >> $NUXEO_HOME/bin/nuxeo.conf
+    cat << EOF >> $NUXEO_CONF
 nuxeo.log.dir=$NUXEO_LOG
 nuxeo.pid.dir=/var/run/nuxeo
 nuxeo.data.dir=$NUXEO_DATA
@@ -97,6 +116,13 @@ EOF
   if [ -n "$NUXEO_PACKAGES" ]; then
     gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
+  for f in /docker-entrypoint-initnuxeo.d/*; do
+    case "$f" in
+      *.sh)  echo "$0: running $f"; . "$f" ;;
+      *)     echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
 
   if [ "$2" = "console" ]; then
     exec gosu $NUXEO_USER nuxeoctl console

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -50,6 +50,7 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
+RUN mkdir /docker-entrypoint-initnuxeo.d
 ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME

--- a/8.1/docker-entrypoint.sh
+++ b/8.1/docker-entrypoint.sh
@@ -62,12 +62,31 @@ if [ "$1" = 'nuxeoctl' ]; then
     mkdir -p ${NUXEO_LOG:=/var/log/nuxeo}
     mkdir -p /var/run/nuxeo
 
+    # The binary store environment variable is defined : 1/ creates the folder with proper rights; 2/ fills in the corresponding property within nuxeo.conf
+    if [ -n "$NUXEO_BINARY_STORE" ]; then
+      mkdir -p $NUXEO_BINARY_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_BINARY_STORE
+      echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
+    fi
+
+    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
+    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
+      mkdir -p $NUXEO_TRANSIENT_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
+
+      #removes transients stores if exists to allow symbolic link creation
+      if [ -d $NUXEO_DATA/transientstores ]; then
+          rm -rf $NUXEO_DATA/transientstores
+      fi
+      mkdir -p $NUXEO_DATA/transientstores
+      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
+    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG
     chown -R $NUXEO_USER:$NUXEO_USER /var/run/nuxeo
 
-    cat << EOF >> $NUXEO_HOME/bin/nuxeo.conf
+    cat << EOF >> $NUXEO_CONF
 nuxeo.log.dir=$NUXEO_LOG
 nuxeo.pid.dir=/var/run/nuxeo
 nuxeo.data.dir=$NUXEO_DATA
@@ -97,6 +116,13 @@ EOF
   if [ -n "$NUXEO_PACKAGES" ]; then
     gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
+  for f in /docker-entrypoint-initnuxeo.d/*; do
+    case "$f" in
+      *.sh)  echo "$0: running $f"; . "$f" ;;
+      *)     echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
 
   if [ "$2" = "console" ]; then
     exec gosu $NUXEO_USER nuxeoctl console

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,6 +50,7 @@ RUN curl -fsSL "http://cdn.nuxeo.com/nuxeo-${NUXEO_VERSION}/nuxeo-cap-${NUXEO_VE
     && rm -rf /tmp/nuxeo-distribution* \
     && chmod +x $NUXEO_HOME/bin/*ctl $NUXEO_HOME/bin/*.sh
 
+RUN mkdir /docker-entrypoint-initnuxeo.d
 ENV PATH $NUXEO_HOME/bin:$PATH
 
 WORKDIR $NUXEO_HOME

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,12 +62,31 @@ if [ "$1" = 'nuxeoctl' ]; then
     mkdir -p ${NUXEO_LOG:=/var/log/nuxeo}
     mkdir -p /var/run/nuxeo
 
+    # The binary store environment variable is defined : 1/ creates the folder with proper rights; 2/ fills in the corresponding property within nuxeo.conf
+    if [ -n "$NUXEO_BINARY_STORE" ]; then
+      mkdir -p $NUXEO_BINARY_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_BINARY_STORE
+      echo "repository.binary.store=$NUXEO_BINARY_STORE" >> $NUXEO_CONF
+    fi
+
+    # The transient store environment variable is defined : 1/ creates the folder with proper rights; 2/ creates the symbolic link as explained in nuxeo cluster documentation
+    if [ -n "$NUXEO_TRANSIENT_STORE" ]; then
+      mkdir -p $NUXEO_TRANSIENT_STORE
+      chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_TRANSIENT_STORE
+
+      #removes transients stores if exists to allow symbolic link creation
+      if [ -d $NUXEO_DATA/transientstores ]; then
+          rm -rf $NUXEO_DATA/transientstores
+      fi
+      mkdir -p $NUXEO_DATA/transientstores
+      ln -s $NUXEO_TRANSIENT_STORE $NUXEO_DATA/transientstores/default
+    fi
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_HOME
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_DATA
     chown -R $NUXEO_USER:$NUXEO_USER $NUXEO_LOG
     chown -R $NUXEO_USER:$NUXEO_USER /var/run/nuxeo
 
-    cat << EOF >> $NUXEO_HOME/bin/nuxeo.conf
+    cat << EOF >> $NUXEO_CONF
 nuxeo.log.dir=$NUXEO_LOG
 nuxeo.pid.dir=/var/run/nuxeo
 nuxeo.data.dir=$NUXEO_DATA
@@ -97,6 +116,13 @@ EOF
   if [ -n "$NUXEO_PACKAGES" ]; then
     gosu $NUXEO_USER nuxeoctl mp-install $NUXEO_PACKAGES --relax=false --accept=true
   fi
+  for f in /docker-entrypoint-initnuxeo.d/*; do
+    case "$f" in
+      *.sh)  echo "$0: running $f"; . "$f" ;;
+      *)     echo "$0: ignoring $f" ;;
+    esac
+    echo
+  done
 
   if [ "$2" = "console" ]; then
     exec gosu $NUXEO_USER nuxeoctl console


### PR DESCRIPTION
For now, extend the nuxeo official image is quite hard. The postgres official image proposes a simple mecanism. Here is the implementatation for nuxeo image 
- Adds an additionnal intialization possibility : scripts under /docker-entrypoint-initnuxeo.d are run before starting the service.

I also added two environments variables to make easiest to use this image to build a nuxeo cluster
- NUXEO_TRANSIENT_STORE
- NUXEO_BINARY_STORE
