### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/5.8/Dockerfile
+++ b/5.8/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:7-jre
+FROM       openjdk:7-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.10/Dockerfile
+++ b/8.10/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jdk
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jre
+FROM       openjdk:8-jre
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       java:8-jdk
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).