### PR TITLE
Use jdk8 as base image instead of jre

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/7.10/Dockerfile
+++ b/7.10/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user

--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM       openjdk:8-jre
+FROM       openjdk:8-jdk
 MAINTAINER Nuxeo <packagers@nuxeo.com>
 
 # Create Nuxeo user


### PR DESCRIPTION
Use JDK8 as default JRE; it makes possible to use image in a development environment