### PR TITLE
Match db password env variable with correct config key

### DIFF
--- a/9.1/nuxeo.conf
+++ b/9.1/nuxeo.conf
@@ -27,7 +27,7 @@ nuxeo.templates=common,${env:NUXEO_DB_TYPE:default},docker,${env:NUXEO_TEMPLATES
 nuxeo.db.host=${env:NUXEO_DB_HOST:localhost}
 nuxeo.db.name=${env:NUXEO_DB_NAME:nuxeo}
 nuxeo.db.user=${env:NUXEO_DB_USER:nuxeo}
-nuxeo.db.user=${env:NUXEO_DB_PASSWORD:nuxeo}
+nuxeo.db.password=${env:NUXEO_DB_PASSWORD:nuxeo}
 
 nuxeo.url=${env:NUXEO_URL}
 


### PR DESCRIPTION
nuxeo.conf file contains incorrect key for db password environment variable