### PR TITLE
Support installation of marketplace ZIPs from subdirectories

### DIFF
--- a/10.10/docker-entrypoint.sh
+++ b/10.10/docker-entrypoint.sh
@@ -42,7 +42,7 @@ EOF
     touch $NUXEO_HOME/configured
   fi
 
-  for f in /docker-entrypoint-initnuxeo.d/*; do
+  find /docker-entrypoint-initnuxeo.d -type f | while read f; do
     case "$f" in
       *.sh)  echo "$0: running $f"; . "$f" ;;
       *.zip) echo "$0: installing Nuxeo package $f"; nuxeoctl mp-install $f ${NUXEO_MPINSTALL_OPTIONS} --accept=true ;;


### PR DESCRIPTION
With this change to the docker entry point script,  it would be possible - running in a Kubernetes cluster - to install marketplace ZIPs from a subdirectory projected into the container from a persistent volume. This supports installing marketplace packages when the Kubernetes cluster doesn't have Internet connectivity to the marketplace. It would also support installing internal custom packages the same way.